### PR TITLE
Fix return code parsing error

### DIFF
--- a/python.sty
+++ b/python.sty
@@ -71,7 +71,7 @@
 \ifwindows
 \immediate\write18{type \@pythoninclude\space\@outname.py 2> nul: | python > \@outname.py.out 2> \@outname.py.err & call echo ^\@percentchar ERRORLEVEL^\@percentchar > \@outname.rc}
 \else
-\immediate\write18{cat \@pythoninclude\space\@outname.py | /usr/bin/env python > \@outname.py.out 2> \@outname.py.err; echo -n $? > \@outname.rc}
+\immediate\write18{cat \@pythoninclude\space\@outname.py | /usr/bin/env python > \@outname.py.out 2> \@outname.py.err; echo $? > \@outname.rc}
 \fi
 \immediate\input\@outname.py.out
 


### PR DESCRIPTION
I got an error when compiling the following with `pdflatex -shell-escape eg.tex`.  The error was:

```
(./eg.out) (./eg.out) [1{/opt/local/var/db/texmf/fonts/map/pdftex/updmap/pdftex
.map}pdfTeX warning (ext4): destination with the same identifier (name{equation
.2.2}) has been already used, duplicate ignored

\AtBegShi@Output ...ipout \box \AtBeginShipoutBox
                                                  \fi \fi
l.84 \begin{verbatim}
                     pdfTeX warning (ext4): destination with the same identifie
r (name{equation.2.2}) has been already used, duplicate ignored

\AtBegShi@Output ...ipout \box \AtBeginShipoutBox
                                                  \fi \fi
l.84 \begin{verbatim}
                     ] [2] (./eg1.py.out)
! Missing number, treated as zero.
<to be read again>
                   n
l.152 \end{python}

?
! Missing = inserted for \ifnum.
<to be read again>
                   n
l.152 \end{python}

?
! Missing number, treated as zero.
<to be read again>
                   n
l.152 \end{python}

?
! You can't use `\numexpr' in horizontal mode.
\ifnumcomp ...\ifnum \numexpr #1\relax #2\numexpr
                                                  #3\relax \expandafter \@fi...
l.152 \end{python}

?
[3] (./eg.aux) )</opt/local/share/texmf-texlive-dist/fonts/type1/public/amsfont
```

It turns out the `write18` command was printing the `-n` flag to the `.rc` file.  I removed the `-n` flag and everything now works.  Tested only on a Mac.  I'm not sure about linux.
